### PR TITLE
Modernize and add existance check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 React Native http cache control for both fetch/XMLHttpRequest and ImageView
 
 - [x] iOS
-- [x] Android
+- [ ] Android (Currently broken)
 
 ## Installation
 
@@ -72,49 +72,30 @@ public class MainActivity extends Activity {
 import * as CacheManager from 'react-native-http-cache';
 
 // invoke API directly when in need
-CacheManager.clear();
+CacheManager.clearCache();
 
 ```
 
 ## API Documentation
 
-#### clear()
+#### clearCache()
 
-Clear cache for all type.
+Clear cache.
 
-Return a promise which indicate the clear state.
+Returns a promise which indicate the clear state.
 
-#### getSize()
+#### getCacheSize()
 
-Get cache size for all type.
+Returns a promise that contain the cache size (in bytes).
 
-Return a promise that contain the cache size(in bytes).
+#### existsInCache(url)
 
-#### clearHttpCache()
+Check if a URL exists in the cache.
 
-Clear cache for fetch/ajax only.
-
-Return a promise which indicate the clear state.
-
-#### getHttpCacheSize()
-
-Get cache size for fetch/ajax only.
-
-Return a promise that contain the cache size(in bytes).
-
-#### clearImageCache()
-
-Clear cache for ImageView only.
-
-Return a promise which indicate the clear state.
-
-#### getImageCacheSize()
-
-Get cache size for ImageView only.
-
-Return a promise that contain the cache size(in bytes).
+Return a promise that indicates the URLs existance in cache (boolean).
 
 ## Authors
 
 - [Deng Yun](https://github.com/tdzl2003) from [React-Native-CN](https://github.com/reactnativecn)
 - [Lv Bingru](https://github.com/lvbingru) from [React-Native-CN](https://github.com/reactnativecn)
+- [Peter Salanki](https://github.com/salanki)

--- a/index.js
+++ b/index.js
@@ -1,63 +1,8 @@
-/**
- * Created by tdzl2_000 on 2015-12-29.
- */
 import { NativeModules } from 'react-native';
-import promisify from 'es6-promisify';
 
 const native = NativeModules.HttpCache;
 
-// Used only with promisify. Transform callback to promise result.
-function translateError(err, result) {
-  if (!err) {
-    return this.resolve(result);
-  }
-  if (typeof err === 'object') {
-    if (err instanceof Error) {
-      return this.reject(ret);
-    }
-    const {message, ...other} = err;
-    return this.reject(Object.assign(new Error(err.message), other));
-  } else if (typeof err === 'string') {
-    return this.reject(new Error(err));
-  }
-  this.reject(Object.assign(new Error(), { origin: err }));
-}
+export const clearCache = native.clearCache;
+export const getCacheSize = native.getHttpCacheSize;
+export const existsInCache = native.existsInCache;
 
-function wrapApi(nativeFunc, argCount) {
-  if (!nativeFunc) {
-    return undefined;
-  }
-  const promisified = promisify(nativeFunc, translateError);
-  if (argCount != undefined){
-    return (...args) => {
-      let _args = args;
-      if (_args.length < argCount) {
-        _args[argCount - 1] = undefined;
-      } else if (_args.length > argCount){
-        _args = _args.slice(0, args);
-      }
-      return promisified(..._args);
-    };
-  } else {
-    return () => {
-      return promisified();
-    };
-  }
-}
-export const clearHttpCache = wrapApi(native.clearCache);
-
-export const getHttpCacheSize = wrapApi(native.getHttpCacheSize);
-
-export const clearImageCache = wrapApi(native.clearImageCache);
-
-export const getImageCacheSize = wrapApi(native.getImageCacheSize);
-
-export async function getSize(){
-  const arr = await Promise.all([getHttpCacheSize(), getImageCacheSize()]);
-  // Get sum of all cache type.
-  return arr.reduce((a,b)=>a+b, 0);
-}
-
-export async function clear(){
-  await Promise.all([clearHttpCache(), clearImageCache()]);
-}

--- a/ios/RCTHttpCache/RCTHttpCache.m
+++ b/ios/RCTHttpCache/RCTHttpCache.m
@@ -7,70 +7,44 @@
 //
 
 #import "RCTHttpCache.h"
-#import "RCTImageLoader.h"
 #import "RCTBridge.h"
 
 @implementation RCTHttpCache
 
-@synthesize bridge = _bridge;
+//@synthesize bridge = _bridge;
 
 RCT_EXPORT_MODULE(HttpCache);
 
-RCT_EXPORT_METHOD(getHttpCacheSize:(RCTResponseSenderBlock)resolve)
+RCT_REMAP_METHOD(existsInCache,
+                 url:(NSString *)url
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSURLCache *httpCache = [NSURLCache sharedURLCache];
-    resolve(@[[NSNull null], @([httpCache currentDiskUsage])]);
+  NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:url]];
+  NSURLCache *httpCache = [NSURLCache sharedURLCache];
+  
+  NSCachedURLResponse *response = [httpCache cachedResponseForRequest: request];
+  BOOL inCache = response != nil;
+  
+  resolve(@(inCache));
 }
 
-RCT_EXPORT_METHOD(clearCache:(RCTResponseSenderBlock)resolve)
+
+RCT_REMAP_METHOD(getHttpCacheSize,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSURLCache *httpCache = [NSURLCache sharedURLCache];
+    resolve(@([httpCache currentDiskUsage]));
+}
+
+RCT_REMAP_METHOD(clearCache,
+                 resolverz:(RCTPromiseResolveBlock)resolve
+                 rejecterz:(RCTPromiseRejectBlock)reject)
 {
     NSURLCache *httpCache = [NSURLCache sharedURLCache];
     [httpCache removeAllCachedResponses];
     resolve(@[[NSNull null]]);
 }
-
-
-RCT_EXPORT_METHOD(getImageCacheSize:(RCTResponseSenderBlock)resolve)
-{
-    NSURLCache *imageCache = [self imageCache];
-    dispatch_queue_t queue = [self imageCacheQueue];
-    if (imageCache == nil || queue == nil) {
-        resolve(@[@"cache not found"]);
-    }
-    dispatch_async(queue, ^{
-        resolve(@[[NSNull null], @([imageCache currentDiskUsage])]);
-    });
-}
-
-RCT_EXPORT_METHOD(clearImageCache:(RCTResponseSenderBlock)resolve)
-{
-    NSURLCache *imageCache = [self imageCache];
-    dispatch_queue_t queue = [self imageCacheQueue];
- 
-    if (imageCache == nil || queue == nil) {
-        resolve(@[@"cache not found"]);
-    }
-
-    dispatch_async(queue, ^{
-        [imageCache removeAllCachedResponses];
-        resolve(@[[NSNull null]]);
-    });
-}
-
-- (NSURLCache *)imageCache
-{
-    RCTImageLoader* loader = _bridge.imageLoader;
-    NSURLCache *cache = [loader valueForKey:@"_URLCache"];
-    
-    return cache;
-}
-
-- (dispatch_queue_t)imageCacheQueue
-{
-    RCTImageLoader* loader = _bridge.imageLoader;
-    dispatch_queue_t queue = [loader valueForKey:@"_URLCacheQueue"];
-    return queue;
-}
-
 
 @end

--- a/package.json
+++ b/package.json
@@ -31,6 +31,5 @@
     "eslint-plugin-react": "^3.13.1"
   },
   "dependencies": {
-    "es6-promisify": "^3.0.0"
   }
 }


### PR DESCRIPTION
* There is no separate image cache anymore, removed the calls for it. 

* RN now supports turning native calls to promises directly, removed boilerplate. 

* Added method to check if a URL exits in the cache.

Android support has not been updated to reflect these changes and is currently broken.